### PR TITLE
Add dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
             <div class="language-selector">
                 <button id="lang-en" class="lang-btn active">English</button>
                 <button id="lang-vi" class="lang-btn">Tiếng Việt</button>
+                <button id="theme-toggle" class="theme-btn">Dark Mode</button>
             </div>
             
             <h1 id="main-title">Two Truths and a Lie</h1>

--- a/script.js
+++ b/script.js
@@ -67,6 +67,7 @@ const exitGameBtn = document.getElementById('exit-game');
 // Language elements
 const langEnBtn = document.getElementById('lang-en');
 const langViBtn = document.getElementById('lang-vi');
+const themeToggleBtn = document.getElementById('theme-toggle');
 
 // Game state
 let roomName;
@@ -610,6 +611,8 @@ const translations = {
         whichIsTrue: 'Which statement is TRUE?',
         submitGuess: 'Submit Guess',
         seeTopicHelp: 'See Topic',
+        darkMode: 'Dark Mode',
+        lightMode: 'Light Mode',
         specialMessage: 'This topic encourages creative and personal statements. Use your imagination!',
         instructions: [
             'Two players join the same room',
@@ -658,6 +661,8 @@ const translations = {
         whichIsTrue: 'Câu nói nào là ĐÚNG?',
         submitGuess: 'Gửi Đáp Án',
         seeTopicHelp: 'Xem Chủ Đề',
+        darkMode: 'Chế độ tối',
+        lightMode: 'Chế độ sáng',
         specialMessage: 'Chủ đề này khuyến khích những câu nói sáng tạo và cá nhân. Hãy sử dụng trí tưởng tượng của bạn!',
         instructions: [
             'Hai người chơi tham gia cùng một phòng',
@@ -706,6 +711,13 @@ document.addEventListener('DOMContentLoaded', function() {
         langViBtn.addEventListener('click', () => {
             console.log('Vietnamese button clicked');
             switchLanguage('vi');
+        });
+    }
+
+    if (themeToggleBtn) {
+        themeToggleBtn.addEventListener('click', () => {
+            document.body.classList.toggle('dark-mode');
+            updateLanguageContent();
         });
     }
     
@@ -853,7 +865,11 @@ function updateLanguageContent() {
         
         const submitGuessBtn = document.getElementById('submit-guess-btn');
         if (submitGuessBtn) submitGuessBtn.textContent = t.submitGuess;
-        
+
+        if (themeToggleBtn) {
+            themeToggleBtn.textContent = document.body.classList.contains('dark-mode') ? t.lightMode : t.darkMode;
+        }
+
         // Recreate topic grid with new language
         if (topicGrid) {
             createTopicGrid();

--- a/style.css
+++ b/style.css
@@ -388,6 +388,28 @@ body {
     color: white;
 }
 
+.theme-btn {
+    padding: 8px 16px;
+    border: 2px solid #6c757d;
+    background: white;
+    color: #6c757d;
+    border-radius: 20px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    font-weight: 500;
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
+    min-height: 44px;
+    min-width: 100px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.theme-btn:hover {
+    background: #f8f9fa;
+}
+
 h1, h2 {
     color: #007bff;
     margin: 20px 0;
@@ -1749,7 +1771,37 @@ button:disabled {
         margin: 5px 0;
     }
     
-    #suggestion-list, #help-suggestion-list {
+#suggestion-list, #help-suggestion-list {
         padding-left: 15px;
     }
+}
+
+/* Dark mode styles */
+body.dark-mode {
+    background: #121212;
+    color: #f8f9fa;
+}
+
+body.dark-mode #app {
+    background: #222;
+    color: #f8f9fa;
+}
+
+body.dark-mode input {
+    background-color: #333;
+    border-color: #555;
+    color: #f8f9fa;
+}
+
+body.dark-mode button {
+    background-color: #444;
+    color: #f8f9fa;
+    border-color: #666;
+}
+
+body.dark-mode .game-instructions,
+body.dark-mode .game-settings,
+body.dark-mode #game-info {
+    background: #333;
+    color: #f8f9fa;
 }


### PR DESCRIPTION
## Summary
- add Dark Mode toggle button
- translate Dark Mode toggle text
- update JS to switch themes
- style the toggle button and dark mode UI

## Testing
- `node --check script.js`
- `npm start` *(fails if port already in use)*

------
https://chatgpt.com/codex/tasks/task_b_687e143dfb608320b05cfb1064153e4a