### PR TITLE
Add basic client-side game history

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,8 +52,10 @@
                 <div class="input-group">
                     <input type="text" id="room-name" placeholder="Enter Room Name">
                 </div>
-                <button id="join-room">Join Room</button>
-                <button id="view-history-btn">View History</button>
+                <div class="button-group">
+                    <button id="join-room">Join Room</button>
+                    <button id="view-history-btn">View History</button>
+                </div>
             </div>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -61,6 +61,7 @@
 
         <div id="history-screen" class="hidden">
             <h2>Game History</h2>
+            <p id="history-instructions">Click a session below to view details.</p>
             <ul id="history-list"></ul>
             <div id="session-detail" class="hidden">
                 <h3>Session Details</h3>

--- a/index.html
+++ b/index.html
@@ -53,13 +53,18 @@
                     <input type="text" id="room-name" placeholder="Enter Room Name">
                 </div>
                 <button id="join-room">Join Room</button>
+                <button id="view-history-btn">View History</button>
             </div>
-            <button id="view-history-btn">View History</button>
         </div>
 
         <div id="history-screen" class="hidden">
             <h2>Game History</h2>
             <ul id="history-list"></ul>
+            <div id="session-detail" class="hidden">
+                <h3>Session Details</h3>
+                <ul id="detail-list"></ul>
+                <button id="back-to-history">Back</button>
+            </div>
             <button id="clear-history">Clear History</button>
             <button id="back-to-menu">Back to Menu</button>
         </div>

--- a/index.html
+++ b/index.html
@@ -54,6 +54,14 @@
                 </div>
                 <button id="join-room">Join Room</button>
             </div>
+            <button id="view-history-btn">View History</button>
+        </div>
+
+        <div id="history-screen" class="hidden">
+            <h2>Game History</h2>
+            <ul id="history-list"></ul>
+            <button id="clear-history">Clear History</button>
+            <button id="back-to-menu">Back to Menu</button>
         </div>
 
         <div id="game-screen" class="hidden">

--- a/script.js
+++ b/script.js
@@ -1572,14 +1572,22 @@ function renderHistory() {
         historyList.appendChild(li);
         return;
     }
-    history.forEach((item, index) => {
+    history.forEach((item) => {
         const li = document.createElement('li');
+        li.classList.add('history-item');
+
+        const textSpan = document.createElement('span');
         const date = new Date(item.timestamp).toLocaleString();
         const p1 = item.players[1];
         const p2 = item.players[2];
         const winnerText = item.winner === 0 ? 'Tie' : `Winner: ${item.players[item.winner]}`;
-        li.textContent = `${date} - ${p1}: ${item.scores[1]} vs ${p2}: ${item.scores[2]} (${winnerText})`;
-        li.style.cursor = 'pointer';
+        textSpan.textContent = `${date} - ${p1}: ${item.scores[1]} vs ${p2}: ${item.scores[2]} (${winnerText})`;
+        const arrow = document.createElement('span');
+        arrow.classList.add('detail-icon');
+        arrow.innerHTML = '&#9654;';
+        li.appendChild(textSpan);
+        li.appendChild(arrow);
+
         li.addEventListener('click', () => showSessionDetails(item));
         historyList.appendChild(li);
     });

--- a/style.css
+++ b/style.css
@@ -1817,6 +1817,10 @@ body.dark-mode #history-screen {
     background: #333;
     color: #f8f9fa;
 }
+body.dark-mode #session-detail {
+    background: #333;
+    color: #f8f9fa;
+}
 
 #history-screen {
     text-align: center;
@@ -1829,5 +1833,10 @@ body.dark-mode #history-screen {
 
 #history-screen li {
     margin: 8px 0;
+    cursor: pointer;
+}
+
+#session-detail {
+    margin-top: 15px;
 }
 

--- a/style.css
+++ b/style.css
@@ -1822,6 +1822,16 @@ body.dark-mode #session-detail {
     color: #f8f9fa;
 }
 
+#history-instructions {
+    margin: 6px 0 12px;
+    font-style: italic;
+    color: #555;
+}
+
+body.dark-mode #history-instructions {
+    color: #ccc;
+}
+
 #history-screen {
     text-align: center;
 }
@@ -1831,16 +1841,37 @@ body.dark-mode #session-detail {
     padding: 0;
 }
 
-#history-screen li {
+#history-screen li.history-item {
     margin: 8px 0;
     cursor: pointer;
     padding: 8px 12px;
     border: 1px solid #ccc;
     border-radius: 5px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    transition: background-color 0.2s ease;
 }
 
-body.dark-mode #history-screen li {
+#history-screen li.history-item:hover {
+    background-color: #f0f0f0;
+}
+
+body.dark-mode #history-screen li.history-item {
     border-color: #555;
+}
+
+body.dark-mode #history-screen li.history-item:hover {
+    background-color: #444;
+}
+
+.detail-icon {
+    font-size: 1.1em;
+    color: #888;
+}
+
+body.dark-mode .detail-icon {
+    color: #bbb;
 }
 
 #session-detail li {

--- a/style.css
+++ b/style.css
@@ -1813,3 +1813,21 @@ body.dark-mode #game-info {
     background: #333;
     color: #f8f9fa;
 }
+body.dark-mode #history-screen {
+    background: #333;
+    color: #f8f9fa;
+}
+
+#history-screen {
+    text-align: center;
+}
+
+#history-screen ul {
+    list-style: none;
+    padding: 0;
+}
+
+#history-screen li {
+    margin: 8px 0;
+}
+

--- a/style.css
+++ b/style.css
@@ -1834,6 +1834,29 @@ body.dark-mode #session-detail {
 #history-screen li {
     margin: 8px 0;
     cursor: pointer;
+    padding: 8px 12px;
+    border: 1px solid #ccc;
+    border-radius: 5px;
+}
+
+body.dark-mode #history-screen li {
+    border-color: #555;
+}
+
+#session-detail li {
+    margin: 6px 0;
+    text-align: left;
+}
+
+.button-group {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.button-group button {
+    flex: 1 1 150px;
 }
 
 #session-detail {


### PR DESCRIPTION
## Summary
- let players view a history of previous games
- capture game results in localStorage when the game ends
- allow viewing, clearing, and returning from the history screen

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_b_687e1d568a3c8320a5c12e6601e5bfbe