### PR TITLE
Add sidebar menu with language & theme controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,13 +13,17 @@
         <p id="countdown" class="countdown"></p>
         </div>
     </div>
+    <button id="menu-btn" class="menu-btn">&#9776;</button>
+    <div id="sidebar" class="sidebar">
+        <button id="close-sidebar" class="close-btn">&times;</button>
+        <div class="language-selector">
+            <button id="lang-en" class="lang-btn active">English</button>
+            <button id="lang-vi" class="lang-btn">Tiếng Việt</button>
+        </div>
+        <button id="theme-toggle" class="theme-btn">Dark Mode</button>
+    </div>
     <div id="app">
         <div id="welcome-screen">
-            <div class="language-selector">
-                <button id="lang-en" class="lang-btn active">English</button>
-                <button id="lang-vi" class="lang-btn">Tiếng Việt</button>
-                <button id="theme-toggle" class="theme-btn">Dark Mode</button>
-            </div>
             
             <h1 id="main-title">Two Truths and a Lie</h1>
             

--- a/script.js
+++ b/script.js
@@ -78,6 +78,9 @@ const backToMenuBtn = document.getElementById('back-to-menu');
 const langEnBtn = document.getElementById('lang-en');
 const langViBtn = document.getElementById('lang-vi');
 const themeToggleBtn = document.getElementById('theme-toggle');
+const menuBtn = document.getElementById('menu-btn');
+const sidebar = document.getElementById('sidebar');
+const closeSidebarBtn = document.getElementById('close-sidebar');
 
 // Game state
 let roomName;
@@ -796,6 +799,18 @@ function initializeApp() {
         themeToggleBtn.addEventListener('click', () => {
             document.body.classList.toggle('dark-mode');
             updateLanguageContent();
+        });
+    }
+
+    if (menuBtn && sidebar) {
+        menuBtn.addEventListener('click', () => {
+            sidebar.classList.toggle('open');
+        });
+    }
+
+    if (closeSidebarBtn && sidebar) {
+        closeSidebarBtn.addEventListener('click', () => {
+            sidebar.classList.remove('open');
         });
     }
     

--- a/style.css
+++ b/style.css
@@ -413,6 +413,61 @@ body {
     background: #f8f9fa;
 }
 
+/* Sidebar menu */
+.menu-btn {
+    position: fixed;
+    top: 15px;
+    left: 15px;
+    background: #007bff;
+    color: #fff;
+    border: none;
+    padding: 10px 15px;
+    font-size: 20px;
+    border-radius: 4px;
+    cursor: pointer;
+    z-index: 1001;
+}
+
+.sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100vh;
+    width: 220px;
+    background: #f8f9fa;
+    box-shadow: 2px 0 5px rgba(0, 0, 0, 0.3);
+    padding: 20px;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    z-index: 1000;
+}
+
+.sidebar.open {
+    transform: translateX(0);
+}
+
+.close-btn {
+    background: none;
+    border: none;
+    font-size: 20px;
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    cursor: pointer;
+}
+
+.sidebar .language-selector {
+    flex-direction: column;
+    align-items: flex-start;
+    margin-bottom: 20px;
+}
+
+.sidebar .lang-btn,
+.sidebar .theme-btn {
+    width: 100%;
+    margin-bottom: 10px;
+}
+
 h1, h2 {
     color: #007bff;
     margin: 20px 0;
@@ -1833,6 +1888,15 @@ body.dark-mode button {
     background-color: #444;
     color: #f8f9fa;
     border-color: #666;
+}
+
+body.dark-mode .sidebar {
+    background: #333;
+    color: #f8f9fa;
+}
+
+body.dark-mode .menu-btn {
+    background: #0056b3;
 }
 
 body.dark-mode .game-instructions,


### PR DESCRIPTION
## Summary
- add menu sidebar container to hold language and theme buttons
- style sidebar and menu button
- wire up sidebar open/close logic in JS

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_b_687e78a1119c8320aac39b600551d3ef