### PR TITLE
Implement viewer mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,6 +83,7 @@
                 </div>
                 <div class="button-group">
                     <button id="join-room">Join Room</button>
+                    <button id="join-viewer">Join as Viewer</button>
                     <button id="view-history-btn">View History</button>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- add viewer join button and translation support
- broadcast topic and statement progress to viewers
- disable interactions for viewer mode
- implement real-time updates for spectators on server and client

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_b_687faae39a6c8320b6fb8491d1805a7f