### PR TITLE
Fix consistent topic highlight

### DIFF
--- a/style.css
+++ b/style.css
@@ -639,10 +639,6 @@ h1, h2 {
     border-color: #0056b3;
 }
 
-.topic-card.highlighted:not(.selected) {
-    background: #e7f3ff;
-    border-color: #007bff;
-}
 .topic-card.easy {
     background: #d4edda;
     border-color: #28a745;
@@ -670,10 +666,16 @@ h1, h2 {
     border-color: #dc3545;
 }
 
+
 .topic-card.adult.selected {
     background: #dc3545;
     color: white;
     border-color: #b21f2d;
+}
+
+.topic-card.highlighted:not(.selected) {
+    background: #e7f3ff;
+    border-color: #007bff;
 }
 
 .topic-card.adult.highlighted:not(.selected) {


### PR DESCRIPTION
## Summary
- move highlight rule after type-specific styles so highlight overrides background

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_b_687fb65e7fcc83209b153f6f4a5898ee